### PR TITLE
V0.60d broadband

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# eMule
+Possibly a version you can build easily
+
+Many outdated libraries, trying to make sense out of it

--- a/srchybrid/Opcodes.h
+++ b/srchybrid/Opcodes.h
@@ -95,7 +95,7 @@
 #define RSAKEYSIZE				384			//384 bits
 #define	MAX_SOURCES_FILE_SOFT	750
 #define	MAX_SOURCES_FILE_UDP	50u
-#define SESSIONMAXTRANS			(PARTSIZE+20*1024) // "Try to send complete chunks" always sends this amount of data
+#define SESSIONMAXTRANS			(1024ui64*1024*1024) // With larger files being shared this needs to be raised accordingly, here set to 1Gb
 #define SESSIONMAXTIME			HR2MS(1)	//1 hour
 #define	MAXFILECOMMENTLEN		128
 #define	PARTSIZE				9728000ui64
@@ -106,9 +106,9 @@
 #define CONFIGFOLDER			_T("config\\")
 #define MAXCONPER5SEC			20
 #define MAXCON5WIN9X			10
-#define	UPLOAD_CLIENT_MAXDATARATE	(25*1024) // max. target upload speed per client
+#define	UPLOAD_CLIENT_MAXDATARATE	(2*1024*1024) // max. target upload speed per client, 2Mbps
 #define	MIN_UP_CLIENTS_ALLOWED	2			// min. clients allowed to download regardless of any other factors. Don't set this too high
-#define	MAX_UP_CLIENTS_ALLOWED	100			// max. clients allowed regardless of any other factors; cannot be below MIN_UP_CLIENTS_ALLOWED+3
+#define	MAX_UP_CLIENTS_ALLOWED	7			// max. clients allowed regardless of any other factors; cannot be below MIN_UP_CLIENTS_ALLOWED+3
 #define DOWNLOADTIMEOUT			SEC2MS(100)
 #define CONSERVTIMEOUT			SEC2MS(25)	// age limit for pending connection attempts
 #define RARE_FILE				50

--- a/srchybrid/UploadQueue.cpp
+++ b/srchybrid/UploadQueue.cpp
@@ -404,6 +404,9 @@ bool CUploadQueue::AcceptNewClient(INT_PTR curUploadSlots) const
 	if (curUploadSlots < max(MIN_UP_CLIENTS_ALLOWED, 4))
 		return true;
 
+	if (curUploadSlots >= MAX_UP_CLIENTS_ALLOWED)
+		return false;
+
 	uint32 MaxSpeed;
 	if (thePrefs.IsDynUpEnabled())
 		MaxSpeed = theApp.lastCommonRouteFinder->GetUpload() / 1024u;
@@ -442,6 +445,9 @@ bool CUploadQueue::ForceNewClient(bool allowEmptyWaitingQueue)
 	INT_PTR curUploadSlots = uploadinglist.GetCount();
 	if (curUploadSlots < MIN_UP_CLIENTS_ALLOWED)
 		return true;
+
+	if (curUploadSlots >= MAX_UP_CLIENTS_ALLOWED)
+		return false;
 
 	if (::GetTickCount() < m_nLastStartUpload + SEC2MS(1) && datarate < 102400)
 		return false;


### PR DESCRIPTION
Given the size of files shared these days, and the much higher bandwidth common available, it is not practical to have tenths of files being upload which cause lots of I/O contention and overhead. It's much better to have few slots at max speed uploading for as long as needed. Specifically `SESSIONMAXTRANS` was too low, disconnecting clients in the upload queue every 9Mb

Ideally these params should be put in config file, so to be tuned based on the need.


The key values that should be configurable are

`SESSIONMAXTRANS`
`SESSIONMAXTIME`
`MAX_UP_CLIENTS_ALLOWED`
`UPLOAD_CLIENT_MAXDATARATE`

This is really a basic starting point, these values should probably all be a function of the available bandwidth, so the user can set one parameter (either bandwidth capacity or upload limit) and these values could be dynamically adjusted.
Static values could cover most scenarios, but ideally it should be adaptive