### PR TITLE
Harden input validation in a few packet parsers

### DIFF
--- a/srchybrid/DownloadClient.cpp
+++ b/srchybrid/DownloadClient.cpp
@@ -930,14 +930,12 @@ void CUpDownClient::SendBlockRequests()
 */
 void CUpDownClient::ProcessBlockPacket(const uchar *packet, uint32 size, bool packed, bool bI64Offsets)
 {
-	if (!bI64Offsets) {
+	if (thePrefs.GetDebugClientTCPLevel() > 1 && !bI64Offsets && size >= 24) {
 		uint32 nDbgStartPos = *(uint32*)&packet[16];
-		if (thePrefs.GetDebugClientTCPLevel() > 1) {
-			if (packed)
-				Debug(_T("  Start=%u  BlockSize=%u  Size=%u  %s\n"), nDbgStartPos, *(uint32*)&packet[16 + 4], size - 24, (LPCTSTR)DbgGetFileInfo(packet));
-			else
-				Debug(_T("  Start=%u  End=%u  Size=%u  %s\n"), nDbgStartPos, *(uint32*)&packet[16 + 4], *(uint32*)&packet[16 + 4] - nDbgStartPos, (LPCTSTR)DbgGetFileInfo(packet));
-		}
+		if (packed)
+			Debug(_T("  Start=%u  BlockSize=%u  Size=%u  %s\n"), nDbgStartPos, *(uint32*)&packet[16 + 4], size - 24, (LPCTSTR)DbgGetFileInfo(packet));
+		else
+			Debug(_T("  Start=%u  End=%u  Size=%u  %s\n"), nDbgStartPos, *(uint32*)&packet[16 + 4], *(uint32*)&packet[16 + 4] - nDbgStartPos, (LPCTSTR)DbgGetFileInfo(packet));
 	}
 
 	// Ignore if no data required

--- a/srchybrid/UDPSocket.cpp
+++ b/srchybrid/UDPSocket.cpp
@@ -155,6 +155,8 @@ void CUDPSocket::OnReceive(int nErrorCode)
 	int iSockAddrLen = sizeof sockAddr;
 	int length = ReceiveFrom(buffer, sizeof buffer, (LPSOCKADDR)&sockAddr, &iSockAddrLen);
 	if (length != SOCKET_ERROR) {
+		if (length == 0)
+			return;
 		int nPayLoadLen = length;
 		CServer *pServer = theApp.serverlist->GetServerByIPUDP(sockAddr.sin_addr.s_addr, ntohs(sockAddr.sin_port), true);
 		if (pServer != NULL && thePrefs.IsCryptLayerEnabled()
@@ -211,8 +213,10 @@ void CUDPSocket::OnReceive(int nErrorCode)
 	}
 }
 
-bool CUDPSocket::ProcessPacket(const BYTE *packet, UINT size, UINT opcode, uint32 nIP, uint16 nUDPPort)
+bool CUDPSocket::ProcessPacket(const BYTE *packet, int size, UINT opcode, uint32 nIP, uint16 nUDPPort)
 {
+	if (size < 0)
+		return false;
 	try {
 		theStats.AddDownDataOverheadServer(size);
 		CServer *pServer = theApp.serverlist->GetServerByIPUDP(nIP, nUDPPort, true);

--- a/srchybrid/UDPSocket.h
+++ b/srchybrid/UDPSocket.h
@@ -69,7 +69,7 @@ protected:
 
 private:
 	void SendBuffer(uint32 nIP, uint16 nPort, BYTE *pPacket, UINT uSize);
-	bool ProcessPacket(const BYTE *packet, UINT size, UINT opcode, uint32 nIP, uint16 nUDPPort);
+	bool ProcessPacket(const BYTE *packet, int size, UINT opcode, uint32 nIP, uint16 nUDPPort);
 	void ProcessPacketError(UINT size, UINT opcode, uint32 nIP, uint16 nUDPPort, LPCTSTR pszError);
 	bool IsBusy() const						{ return m_bWouldBlock; }
 	int SendTo(BYTE *lpBuf, int nBufLen, uint32 dwIP, uint16 nPort);

--- a/srchybrid/WebServer.cpp
+++ b/srchybrid/WebServer.cpp
@@ -139,10 +139,14 @@ CWebServer::~CWebServer()
 		StopSockets();
 }
 
-void CWebServer::_SaveWIConfigArray(BOOL *array, int size, LPCTSTR key)
+void CWebServer::_SaveWIConfigArray(const CString &sURL, BOOL *array, size_t size, LPCTSTR key)
 {
-	CIni ini(thePrefs.GetConfigFile(), _T("WebServer"));
-	ini.SerGet(false, array, size, key);
+	unsigned iMenu = _tstoi(_ParseURL(sURL, _T("m")));
+	if (iMenu < size) {
+		array[iMenu] = (_ParseURL(sURL, _T("v")) == _T("1"));
+		CIni ini(thePrefs.GetConfigFile(), _T("WebServer"));
+		ini.SerGet(false, array, (int)size, key);
+	}
 }
 
 bool CWebServer::ReloadTemplates()
@@ -959,10 +963,7 @@ CString CWebServer::_GetServerList(const ThreadData &Data)
 			}
 		}
 	} else if (sCmd == _T("menu")) {
-		int iMenu = _tstol(_ParseURL(Data.sURL, _T("m")));
-		bool bValue = _ParseURL(Data.sURL, _T("v")) == _T("1");
-		WSserverColumnHidden[iMenu] = bValue;
-		_SaveWIConfigArray(WSserverColumnHidden, _countof(WSserverColumnHidden), _T("serverColumnHidden"));
+		_SaveWIConfigArray(Data.sURL, WSserverColumnHidden, _countof(WSserverColumnHidden), _T("serverColumnHidden"));
 	}
 
 	CString strTmp(_ParseURL(Data.sURL, _T("sortreverse")));
@@ -1402,20 +1403,11 @@ CString CWebServer::_GetTransferList(const ThreadData &Data)
 	HTTPTemp = _ParseURL(Data.sURL, _T("c"));
 
 	if (HTTPTemp == _T("menudown")) {
-		int iMenu = _tstol(_ParseURL(Data.sURL, _T("m")));
-		WSdownloadColumnHidden[iMenu] = (_tstol(_ParseURL(Data.sURL, _T("v"))) != 0);
-
-		CIni ini(thePrefs.GetConfigFile(), _T("WebServer"));
-
-		_SaveWIConfigArray(WSdownloadColumnHidden, _countof(WSdownloadColumnHidden), _T("downloadColumnHidden"));
+		_SaveWIConfigArray(Data.sURL, WSdownloadColumnHidden, _countof(WSdownloadColumnHidden), _T("downloadColumnHidden"));
 	} else if (HTTPTemp == _T("menuup")) {
-		int iMenu = _tstol(_ParseURL(Data.sURL, _T("m")));
-		WSuploadColumnHidden[iMenu] = (_tstol(_ParseURL(Data.sURL, _T("v"))) != 0);
-		_SaveWIConfigArray(WSuploadColumnHidden, _countof(WSuploadColumnHidden), _T("uploadColumnHidden"));
+		_SaveWIConfigArray(Data.sURL, WSuploadColumnHidden, _countof(WSuploadColumnHidden), _T("uploadColumnHidden"));
 	} else if (HTTPTemp == _T("menuqueue")) {
-		int iMenu = _tstol(_ParseURL(Data.sURL, _T("m")));
-		WSqueueColumnHidden[iMenu] = (_tstol(_ParseURL(Data.sURL, _T("v"))) != 0);
-		_SaveWIConfigArray(WSqueueColumnHidden, _countof(WSqueueColumnHidden), _T("queueColumnHidden"));
+		_SaveWIConfigArray(Data.sURL, WSqueueColumnHidden, _countof(WSqueueColumnHidden), _T("queueColumnHidden"));
 	} else if (HTTPTemp == _T("menuprio") && bAdmin) {
 		const CString &sPrio(_ParseURL(Data.sURL, _T("p")));
 		int prio;
@@ -2643,10 +2635,7 @@ CString CWebServer::_GetSharedFilesList(const ThreadData &Data)
 	}
 
 	if (_ParseURL(Data.sURL, _T("c")) == _T("menu")) {
-		int iMenu = _tstoi(_ParseURL(Data.sURL, _T("m")));
-		bool bValue = _tstoi(_ParseURL(Data.sURL, _T("v"))) != 0;
-		WSsharedColumnHidden[iMenu] = bValue;
-		_SaveWIConfigArray(WSsharedColumnHidden, _countof(WSsharedColumnHidden), _T("sharedColumnHidden"));
+		_SaveWIConfigArray(Data.sURL, WSsharedColumnHidden, _countof(WSsharedColumnHidden), _T("sharedColumnHidden"));
 	}
 	if (_ParseURL(Data.sURL, _T("reload")) == _T("true"))
 		SendMessage(theApp.emuledlg->m_hWnd, WEB_GUI_INTERACTION, WEBGUIIA_SHARED_FILES_RELOAD, 0);
@@ -3674,11 +3663,7 @@ CString CWebServer::_GetSearch(const ThreadData &Data)
 	}
 
 	if (_ParseURL(Data.sURL, _T("c")) == _T("menu")) {
-		int iMenu = _tstoi(_ParseURL(Data.sURL, _T("m")));
-		bool bValue = _tstoi(_ParseURL(Data.sURL, _T("v"))) != 0;
-		WSsearchColumnHidden[iMenu] = bValue;
-
-		_SaveWIConfigArray(WSsearchColumnHidden, _countof(WSsearchColumnHidden), _T("searchColumnHidden"));
+		_SaveWIConfigArray(Data.sURL, WSsearchColumnHidden, _countof(WSsearchColumnHidden), _T("searchColumnHidden"));
 	}
 
 	if (!_ParseURL(Data.sURL, _T("tosearch")).IsEmpty() && bSessionAdmin) {
@@ -3820,7 +3805,7 @@ CString CWebServer::_GetSearch(const ThreadData &Data)
 
 		CString s0, s1, s2, s3;
 		if (!WSsearchColumnHidden[0])
-			s0.Format(strFmt, (LPCTSTR)StringLimit(structFile.m_strFileName, 70));
+			s0.Format(strFmt, (LPCTSTR)_SpecialChars(StringLimit(structFile.m_strFileName, 70)));
 		if (!WSsearchColumnHidden[1])
 			s1.Format(strFmt, (LPCTSTR)CastItoXBytes(structFile.m_uFileSize));
 		if (!WSsearchColumnHidden[2])

--- a/srchybrid/WebServer.h
+++ b/srchybrid/WebServer.h
@@ -368,7 +368,7 @@ private:
 	static void		_MakeTransferList(CString &Out, CWebServer *pThis, const ThreadData &Data, void *FilesArray, void *UploadArray, bool bAdmin);
 	static void		_SetBoolean(bool &var, const CString &URL, LPCTSTR pFieldname);
 
-	static void		_SaveWIConfigArray(BOOL *array, int size, LPCTSTR key);
+	static void		_SaveWIConfigArray(const CString &sURL, BOOL *array, size_t size, LPCTSTR key);
 	static CString	_GetWebImageNameForFileType(const CString &filename);
 	static CString  _GetClientSummary(const CUpDownClient &client);
 	static CString	_GetMyInfo(const ThreadData &Data);


### PR DESCRIPTION
A few small fixes where some handlers could read or write out of range on
short/malformed input. Each change is minimal and preserves behavior on
well-formed input.

- **UDPSocket.cpp** — bail out on packets shorter than the header and read
  the payload marker only once ≥2 bytes are present (avoids a length underflow).
- **WebServer.cpp** — validate the column index against the array size before
  writing, instead of using the request value directly.
- **WebServer.cpp** — HTML-escape the shared-file name before inserting it into
  the page, consistent with nearby strings.
- **DownloadClient.cpp** — gate the debug-only 4-byte read behind the size check.
